### PR TITLE
Scan repo and deploy to Render

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python controller.py
+web: gunicorn -k eventlet -w 1 controller:app --bind 0.0.0.0:$PORT


### PR DESCRIPTION
Update Procfile to use the correct Gunicorn start command for Render deployment.

The previous `Procfile` command `web: python controller.py` was conflicting with Render's Gunicorn setup, which expected `controller:app` as specified in `render.yaml`. This led to a `ModuleNotFoundError: No module named 'app'`. Aligning the `Procfile` with the `render.yaml`'s `startCommand` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cef64f7-21c1-4012-a453-bd723b7eac3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9cef64f7-21c1-4012-a453-bd723b7eac3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

