### PR TITLE
Say hello

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -1,7 +1,7 @@
 import eventlet
 eventlet.monkey_patch()
 
-from flask import Flask, request, jsonify, redirect, url_for, Response, send_file, session, flash
+from flask import Flask, request, jsonify, redirect, url_for, Response, send_file, session, flash, render_template_string
 from flask_socketio import SocketIO, emit, join_room, leave_room
 from collections import defaultdict
 import datetime
@@ -179,7 +179,7 @@ def login():
     if is_ip_blocked(client_ip):
         remaining_time = Config.LOGIN_TIMEOUT - (datetime.datetime.now() - LOGIN_ATTEMPTS[client_ip][1]).total_seconds()
         flash(f'Too many failed login attempts. Please try again in {int(remaining_time)} seconds.', 'error')
-        return '''
+        return render_template_string('''
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -285,7 +285,7 @@ def login():
         </div>
     </body>
     </html>
-    '''
+    ''')
     
     if request.method == 'POST':
         password = request.form.get('password', '')
@@ -309,7 +309,7 @@ def login():
             else:
                 flash(f'Too many failed attempts. Please wait {Config.LOGIN_TIMEOUT} seconds.', 'error')
     
-    return '''
+    return render_template_string('''
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -459,7 +459,7 @@ def login():
         </div>
     </body>
     </html>
-    '''
+    ''')
 
 # Logout route
 @app.route('/logout')


### PR DESCRIPTION
Fix Jinja2 template rendering in the login page by using `render_template_string`.

Previously, the login route returned raw HTML strings containing Jinja2 syntax, which Flask did not process. This resulted in the template tags being displayed directly in the browser. By wrapping these strings with `render_template_string`, Flask now correctly processes the templates server-side, ensuring flash messages and other dynamic content are rendered as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-d99ca786-d3e3-4747-b69d-c57e6f9ef56a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d99ca786-d3e3-4747-b69d-c57e6f9ef56a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

